### PR TITLE
Show sparse array holes in assertion diffs

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -28,6 +28,13 @@ const shouldDoOwnCompare = (operator) =>
 function getCauseFromError(error) {
   const cause = error.cause
   if (cause && shouldDoOwnCompare(cause.operator)) {
+    if (
+      cause.message &&
+      hasSparseArrayDifference(cause.actual, cause.expected)
+    ) {
+      return cause.message
+    }
+
     const expectation = operatorToHumanExpectation[cause.operator]
     const shouldHaveLegends = !cause.operator.startsWith('not')
     return `Expected values to ${expectation}:${
@@ -40,6 +47,39 @@ function getCauseFromError(error) {
   } else {
     return String(error)
   }
+}
+
+function hasSparseArrayDifference(actual, expected) {
+  if (Array.isArray(actual) && Array.isArray(expected)) {
+    const maxLength = Math.max(actual.length, expected.length)
+    for (let index = 0; index < maxLength; index++) {
+      const hasActual = Object.hasOwn(actual, index)
+      const hasExpected = Object.hasOwn(expected, index)
+      if (hasActual !== hasExpected) {
+        return true
+      }
+      if (
+        hasActual &&
+        hasExpected &&
+        hasSparseArrayDifference(actual[index], expected[index])
+      ) {
+        return true
+      }
+    }
+  } else if (
+    actual &&
+    expected &&
+    typeof actual === 'object' &&
+    typeof expected === 'object'
+  ) {
+    for (const key of new Set([...Object.keys(actual), ...Object.keys(expected)])) {
+      if (hasSparseArrayDifference(actual[key], expected[key])) {
+        return true
+      }
+    }
+  }
+
+  return false
 }
 
 /**

--- a/lib/format.js
+++ b/lib/format.js
@@ -80,8 +80,9 @@ const ensureEndingLineshift = (str) => (str.endsWith('\n') ? str : `${str}\n`)
 
 function formatCauseLine(line) {
   if (typeof line === 'string') {
-    if (line === '+ expected - actual') {
-      return `${colorOk('+')} expected ${colorError('-')} actual`
+    const legend = line.match(/^\+ (expected|actual) - (expected|actual)$/)
+    if (legend) {
+      return `${colorOk('+')} ${legend[1]} ${colorError('-')} ${legend[2]}`
     } else if (line.startsWith('+')) {
       return `${colorOk('+')}${line.slice(1)} `
     } else if (line.startsWith('-')) {

--- a/tests/cases/failingSparseArray.js
+++ b/tests/cases/failingSparseArray.js
@@ -1,0 +1,10 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+test('should fail with sparse array diff', () => {
+  const value = Array(3)
+  value[2] = { id: 'ent1' }
+  const expected = [undefined, undefined, { id: 'ent1' }]
+
+  assert.deepEqual(value, expected)
+})

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -30,6 +30,19 @@ test('should output deep equal error', async (t) => {
   t.match(result[result.length - 1], expected)
 })
 
+test('should output sparse array differences', async (t) => {
+  const result = await runTests(['failingSparseArray'])
+  const output = result[result.length - 1]
+
+  t.match(
+    output,
+    /^ \n\nTest 'should fail with sparse array diff' failed\nin file '\/tests\/cases\/failingSparseArray.js', line 9, column 10/,
+  )
+  t.match(output, /Expected values to be strictly deep-equal:\n\+ actual - expected/)
+  t.match(output, /\+ {3}<2 empty items>,/)
+  t.match(output, /- {3}undefined,/)
+})
+
 test('should output error from ok', async (t) => {
   const expected =
     /^ \n\nTest 'should fail with ok' failed\nin file '\/tests\/cases\/failingOk\.js', line 5, column 10\n\nThe expression evaluated to a falsy value:\n\n\s\sassert\.ok\(false\)\n/


### PR DESCRIPTION
## Summary
- detect sparse-array hole differences before using concordance
- preserve Node assertion output for sparse-array diffs so `<empty items>` is shown
- add reporter regression coverage for sparse arrays vs explicit `undefined` entries

Closes #32

## Verification
- npm_config_cache=/tmp/node-test-reporter-32-npm-cache npx tape tests/errors.test.js | npx tap-min
- npm_config_cache=/tmp/node-test-reporter-32-npm-cache npm run verify
- git diff --check HEAD~1 HEAD